### PR TITLE
support `Base.eltype` for `QuantumObject`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,6 +19,7 @@ isket
 isoper
 issuper
 size
+eltype
 length
 LinearAlgebra.tr
 LinearAlgebra.norm

--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -148,8 +148,12 @@ Returns the size of the matrix or vector corresponding to the [`QuantumObject`](
 Base.size(A::QuantumObject{<:AbstractArray{T},OpType}) where {T,OpType<:QuantumObjectType} = size(A.data)
 Base.size(A::QuantumObject{<:AbstractArray{T},OpType}, inds...) where {T,OpType<:QuantumObjectType} = size(A.data, inds...)
 
-Base.getindex(A::QuantumObject{<:AbstractArray{T},OpType}, inds...) where {T,OpType<:QuantumObjectType} = getindex(A.data, inds...)
-Base.setindex!(A::QuantumObject{<:AbstractArray{T},OpType}, val, inds...) where {T,OpType<:QuantumObjectType} = setindex!(A.data, val, inds...)
+"""
+    eltype(A::QuantumObject)
+
+Returns the elements type of the matrix or vector corresponding to the [`QuantumObject`](@ref) `A`.
+"""
+Base.eltype(A::QuantumObject, inds...) = eltype(A.data)
 
 #    Broadcasting
 Base.broadcastable(x::QuantumObject) = x.data

--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -148,6 +148,9 @@ Returns the size of the matrix or vector corresponding to the [`QuantumObject`](
 Base.size(A::QuantumObject{<:AbstractArray{T},OpType}) where {T,OpType<:QuantumObjectType} = size(A.data)
 Base.size(A::QuantumObject{<:AbstractArray{T},OpType}, inds...) where {T,OpType<:QuantumObjectType} = size(A.data, inds...)
 
+Base.getindex(A::QuantumObject{<:AbstractArray{T},OpType}, inds...) where {T,OpType<:QuantumObjectType} = getindex(A.data, inds...)
+Base.setindex!(A::QuantumObject{<:AbstractArray{T},OpType}, val, inds...) where {T,OpType<:QuantumObjectType} = setindex!(A.data, val, inds...)
+
 """
     eltype(A::QuantumObject)
 

--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -153,7 +153,7 @@ Base.size(A::QuantumObject{<:AbstractArray{T},OpType}, inds...) where {T,OpType<
 
 Returns the elements type of the matrix or vector corresponding to the [`QuantumObject`](@ref) `A`.
 """
-Base.eltype(A::QuantumObject, inds...) = eltype(A.data)
+Base.eltype(A::QuantumObject) = eltype(A.data)
 
 #    Broadcasting
 Base.broadcastable(x::QuantumObject) = x.data


### PR DESCRIPTION
This helps to directly obtain the element type in `QuantumObject.data`, e.g., `Int64`, `Float64`, `ComplexF64` ...
I think this would be quite useful when developing new functionality in the future.