### PR TITLE
Calculate Negativity

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,6 +38,8 @@ tidyup
 tidyup!
 gaussian
 ptrace
+partial_transpose
+negativity
 entropy_vn
 entanglement
 expect

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -50,7 +50,7 @@ export WignerClenshaw, WignerLaguerre, wigner
 export row_major_reshape, tidyup, tidyup!, gaussian, trunc_op, meshgrid, sparse_to_dense, dense_to_sparse
 export get_data, mat2vec, vec2mat
 export ptrace, entropy_vn, entanglement
-export partial_transpose
+export negativity, partial_transpose
 export get_coherence, n_th
 export dfd_mesolve, dsf_mesolve, dsf_mcsolve
 export liouvillian, liouvillian_floquet, liouvillian_generalized, steadystate, steadystate_floquet

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -35,6 +35,7 @@ include("wigner.jl")
 include("spin_lattice.jl")
 include("arnoldi.jl")
 include("eigsolve.jl")
+include("negativity.jl")
 
 export QuantumObject, Qobj, BraQuantumObject, KetQuantumObject, OperatorQuantumObject, SuperOperatorQuantumObject, TimeEvolutionSol
 export isket, isbra, isoper, issuper, ket2dm

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -49,6 +49,7 @@ export WignerClenshaw, WignerLaguerre, wigner
 export row_major_reshape, tidyup, tidyup!, gaussian, trunc_op, meshgrid, sparse_to_dense, dense_to_sparse
 export get_data, mat2vec, vec2mat
 export ptrace, entropy_vn, entanglement
+export partial_transpose
 export get_coherence, n_th
 export dfd_mesolve, dsf_mesolve, dsf_mcsolve
 export liouvillian, liouvillian_floquet, liouvillian_generalized, steadystate, steadystate_floquet

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -245,8 +245,8 @@ function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumO
     nsys = length(mask)
     pt_dims = reshape(Vector(1:(2 * nsys)), (nsys, 2))
     pt_idx  = [
-        [pt_dims[n,     mask[n]] for n in 1:nsys];
-        [pt_dims[n, 3 - mask[n]] for n in 1:nsys]
+        [pt_dims[n,     mask[n]] for n in 1:nsys]; # origin   value in mask
+        [pt_dims[n, 3 - mask[n]] for n in 1:nsys]  # opposite value in mask (1 -> 2, and 2 -> 1)
     ]
     return reshape(
         permutedims(

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -248,12 +248,10 @@ function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumO
         [pt_dims[n,     mask[n]] for n in 1:nsys]; # origin   value in mask
         [pt_dims[n, 3 - mask[n]] for n in 1:nsys]  # opposite value in mask (1 -> 2, and 2 -> 1)
     ]
-    return reshape(
-        permutedims(
-            reshape(ρ.data, (ρ.dims..., ρ.dims...)), 
-            pt_idx
-        ), 
-        size(ρ)
+    return QuantumObject(
+        reshape(permutedims(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
+        OperatorQuantumObject,
+        ρ.dims
     )
 end
 

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -227,6 +227,36 @@ function entropy_vn(ρ::QuantumObject{<:AbstractArray{T},OperatorQuantumObject};
     return -real(sum(nzvals .* logvals))
 end
 
+@doc raw"""
+    partial_transpose(ρ::QuantumObject, mask::Vector{Bool})
+
+Return the partial transpose of a density matrix ``\rho``, where `mask` is an array/vector with length that equals the length of `ρ.dims`. The elements in `mask` are boolean (`true` or `false`) which indicates whether or not the corresponding subsystem should be transposed.
+"""
+function partial_transpose(ρ::QuantumObject{::T, OperatorQuantumObject}, mask::Vector{Bool}) where T
+    if length(mask) != length(ρ.dims) 
+        error("The length of \`mask\` should be equal to the length of \`ρ.dims\`.")
+    end
+    return _partial_transpose(ρ, [1 + Int(i) for i in mask])
+end
+function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumObject}, mask::Vector{Int})
+    # mask has elements with values equal to 1 or 2
+    # 1 - the subsystem don't need to be transposed
+    # 2 - the subsystem need be transposed
+    nsys = length(mask)
+    pt_dims = reshape(Vector(1:(2 * nsys)), (nsys, 2))
+    pt_idx  = [
+        [pt_dims[n,     mask[n]] for n in 1:nsys];
+        [pt_dims[n, 3 - mask[n]] for n in 1:nsys]
+    ]
+    return reshape(
+        permutedims(
+            reshape(ρ.data, (ρ.dims..., ρ.dims...)), 
+            pt_idx
+        ), 
+        size(ρ)
+    )
+end
+
 """
     entanglement(QO::QuantumObject, sel::Vector)
 

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -227,34 +227,6 @@ function entropy_vn(ρ::QuantumObject{<:AbstractArray{T},OperatorQuantumObject};
     return -real(sum(nzvals .* logvals))
 end
 
-@doc raw"""
-    partial_transpose(ρ::QuantumObject, mask::Vector{Bool})
-
-Return the partial transpose of a density matrix ``\rho``, where `mask` is an array/vector with length that equals the length of `ρ.dims`. The elements in `mask` are boolean (`true` or `false`) which indicates whether or not the corresponding subsystem should be transposed.
-"""
-function partial_transpose(ρ::QuantumObject{::T, OperatorQuantumObject}, mask::Vector{Bool}) where T
-    if length(mask) != length(ρ.dims) 
-        error("The length of \`mask\` should be equal to the length of \`ρ.dims\`.")
-    end
-    return _partial_transpose(ρ, [1 + Int(i) for i in mask])
-end
-function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumObject}, mask::Vector{Int})
-    # mask has elements with values equal to 1 or 2
-    # 1 - the subsystem don't need to be transposed
-    # 2 - the subsystem need be transposed
-    nsys = length(mask)
-    pt_dims = reshape(Vector(1:(2 * nsys)), (nsys, 2))
-    pt_idx  = [
-        [pt_dims[n,     mask[n]] for n in 1:nsys]; # origin   value in mask
-        [pt_dims[n, 3 - mask[n]] for n in 1:nsys]  # opposite value in mask (1 -> 2, and 2 -> 1)
-    ]
-    return QuantumObject(
-        reshape(permutedims(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
-        OperatorQuantumObject,
-        ρ.dims
-    )
-end
-
 """
     entanglement(QO::QuantumObject, sel::Vector)
 

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -1,0 +1,30 @@
+@doc raw"""
+    partial_transpose(ρ::QuantumObject, mask::Vector{Bool})
+
+Return the partial transpose of a density matrix ``\rho``, where `mask` is an array/vector with length that equals the length of `ρ.dims`. The elements in `mask` are boolean (`true` or `false`) which indicates whether or not the corresponding subsystem should be transposed.
+"""
+function partial_transpose(ρ::QuantumObject{::T, OperatorQuantumObject}, mask::Vector{Bool}) where T
+    if length(mask) != length(ρ.dims) 
+        error("The length of \`mask\` should be equal to the length of \`ρ.dims\`.")
+    end
+    return _partial_transpose(ρ, mask)
+end
+
+function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumObject}, mask::Vector{Bool})
+    mask2 = [1 + Int(i) for i in mask]
+    # mask2 has elements with values equal to 1 or 2
+    # 1 - the subsystem don't need to be transposed
+    # 2 - the subsystem need be transposed
+
+    nsys = length(mask2)
+    pt_dims = reshape(Vector(1:(2 * nsys)), (nsys, 2))
+    pt_idx  = [
+        [pt_dims[n,     mask2[n]] for n in 1:nsys]; # origin   value in mask2
+        [pt_dims[n, 3 - mask2[n]] for n in 1:nsys]  # opposite value in mask2 (1 -> 2, and 2 -> 1)
+    ]
+    return QuantumObject(
+        reshape(permutedims(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
+        OperatorQuantumObject,
+        ρ.dims
+    )
+end

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -1,7 +1,9 @@
 @doc raw"""
     negativity(ρ::QuantumObject, subsys::Int; logarithmic::Bool=false)
 
-Compute the [negativity](https://en.wikipedia.org/wiki/Negativity_(quantum_mechanics))
+Compute the [negativity](https://en.wikipedia.org/wiki/Negativity_(quantum_mechanics)) ``N(\rho) = \frac{\Vert \rho^{\Gamma}\Vert_1 - 1}{2}``  
+where ``\rho^{\Gamma}`` is the partial transpose of ``\rho`` with respect to the subsystem,  
+and ``\Vert X \Vert_1=\Tr\sqrt{X^\dagger X}`` is the trace norm.
 
 # Arguments
 - `ρ::QuantumObject`: The density matrix (`ρ.type` must be `OperatorQuantumObject`).

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -2,14 +2,22 @@
     partial_transpose(ρ::QuantumObject, mask::Vector{Bool})
 
 Return the partial transpose of a density matrix ``\rho``, where `mask` is an array/vector with length that equals the length of `ρ.dims`. The elements in `mask` are boolean (`true` or `false`) which indicates whether or not the corresponding subsystem should be transposed.
+
+# Arguments
+- `ρ::QuantumObject`: The density matrix (the type must be `OperatorQuantumObject`).
+- `mask::Vector{Bool}`: A boolean vector selects which subsystems should be transposed.
+
+# Returns
+- `ρ_pt::QuantumObject`: The density matrix with the selected subsystems transposed.
 """
-function partial_transpose(ρ::QuantumObject{::T, OperatorQuantumObject}, mask::Vector{Bool}) where T
+function partial_transpose(ρ::QuantumObject{T, OperatorQuantumObject}, mask::Vector{Bool}) where T
     if length(mask) != length(ρ.dims) 
         error("The length of \`mask\` should be equal to the length of \`ρ.dims\`.")
     end
     return _partial_transpose(ρ, mask)
 end
 
+# for dense matrices
 function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumObject}, mask::Vector{Bool})
     mask2 = [1 + Int(i) for i in mask]
     # mask2 has elements with values equal to 1 or 2
@@ -24,6 +32,48 @@ function _partial_transpose(ρ::QuantumObject{<:AbstractMatrix, OperatorQuantumO
     ]
     return QuantumObject(
         reshape(permutedims(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
+        OperatorQuantumObject,
+        ρ.dims
+    )
+end
+
+# for sparse matrices
+function _partial_transpose(ρ::QuantumObject{<:AbstractSparseArray, OperatorQuantumObject}, mask::Vector{Bool})
+    M, N = size(ρ)
+    dimsTuple = Tuple(ρ.dims)
+    colptr = ρ.data.colptr
+    rowval = ρ.data.rowval
+    nzval  = ρ.data.nzval
+    len = length(nzval)
+
+    # for partial transposed data
+    I_pt = Vector{Int}(undef, len)
+    J_pt = Vector{Int}(undef, len)
+    V_pt = Vector{eltype(ρ)}(undef, len)
+
+    n = 0
+    for j in 1:(length(colptr) - 1)
+        for p in colptr[j]:(colptr[j + 1] - 1)
+            n += 1
+            i = rowval[p]
+            if i == j
+                I_pt[n] = i
+                J_pt[n] = j
+            else
+                ket_pt = [Base._ind2sub(dimsTuple, i)...]
+                bra_pt = [Base._ind2sub(dimsTuple, j)...]
+                for sys in findall(m -> m, mask)
+                    @inbounds ket_pt[sys], bra_pt[sys] = bra_pt[sys], ket_pt[sys]
+                end
+                I_pt[n] = Base._sub2ind(dimsTuple, ket_pt...)
+                J_pt[n] = Base._sub2ind(dimsTuple, bra_pt...)
+            end
+            V_pt[n] = nzval[p]
+        end
+    end
+
+    return QuantumObject(
+        sparse(I_pt, J_pt, V_pt, M, N),
         OperatorQuantumObject,
         ρ.dims
     )

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -12,6 +12,29 @@ and ``\Vert X \Vert_1=\Tr\sqrt{X^\dagger X}`` is the trace norm.
 
 # Returns
 - `N::Real`: The value of negativity.
+
+# Examples
+
+```
+julia> Ψ = 1 / √2 * ( basis(2,0) ⊗ basis(2,0) + basis(2,1) ⊗ basis(2,1) )
+Quantum Object:   type=Ket   dims=[2, 2]   size=(4,)
+4-element Vector{ComplexF64}:
+ 0.7071067811865475 + 0.0im
+                0.0 + 0.0im
+                0.0 + 0.0im
+ 0.7071067811865475 + 0.0im
+
+julia> ρ = ket2dm(Ψ)
+Quantum Object:   type=Operator   dims=[2, 2]   size=(4, 4)   ishermitian=true
+4×4 Matrix{ComplexF64}:
+ 0.5+0.0im  0.0+0.0im  0.0+0.0im  0.5+0.0im
+ 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
+ 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
+ 0.5+0.0im  0.0+0.0im  0.0+0.0im  0.5+0.0im
+
+julia> negativity(ρ, 2)
+0.4999999999999998
+```
 """
 function negativity(ρ::QuantumObject, subsys::Int; logarithmic::Bool=false)
     mask = fill(false, length(ρ.dims))
@@ -30,8 +53,6 @@ function negativity(ρ::QuantumObject, subsys::Int; logarithmic::Bool=false)
         return (tr_norm - 1) / 2
     end
 end
-
-
 
 @doc raw"""
     partial_transpose(ρ::QuantumObject, mask::Vector{Bool})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,6 +563,38 @@ end
     @test entanglement(state, [1]) / log(2) ≈ 1
 end
 
+@testset "Negativity and Partial Transpose" begin
+    # tests for negativity
+    rho = (1 / 40) * Qobj([
+        15  1  1 15;
+         1  5 -3  1;
+         1 -3  5  1;
+        15  1  1 15];
+        dims = [2, 2]
+    )
+    Neg = negativity(rho, 1)
+    @test Neg ≈ 0.25
+    @test negativity(rho, 2) ≈ Neg
+    @test negativity(rho, 1; logarithmic=true) ≈ log2(2 * Neg + 1)
+    @test_throws ErrorException negativity(rho, 0)
+    @test_throws ErrorException negativity(rho, 3)
+
+    # tests for partial transpose (PT)
+    # A (24 * 24)-matrix which contains number 1 ~ 576
+    A_dense  = Qobj(reshape(1:(24^2), (24, 24)), dims = [2, 3, 4])
+    A_sparse = dense_to_sparse(A_d)
+    PT = (true, false)
+    for s1 in PT
+        for s2 in PT
+            for s3 in PT
+                mask = [s1, s2, s3]
+                @test partial_transpose(A_dense, mask) == partial_transpose(A_sparse, mask)
+            end
+        end
+    end
+    @test_throws ErrorException negativity(rho, [])
+end
+
 @testset "Wigner" begin
     α = 0.5 + 0.8im
     ψ = coherent(30, α)


### PR DESCRIPTION
1. New exported functions:
    - [ ] `negativity`
    - [ ] `partial_transpose` (for either dense or sparse `QuantumOpjects`, but only allow `type=OperatorQuantumObject`)

2. New runtest set for above functions