### PR TITLE
Fix compat with DiffEqCallbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-DiffEqCallbacks = "2.24, <3.2.0"
+DiffEqCallbacks = "2.24, <3.2.0, >=3.5.0"
 FFTW = "1.5"
 Graphs = "1.7.4"
 IncompleteLU = "0.2"


### PR DESCRIPTION
The excluded versions add some extra allocations. Thus, we want to avoid them