### PR TITLE
Modify `QuantumObject` strings in `show()`

### DIFF
--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -181,12 +181,12 @@ function _check_QuantumObject(type::SuperOperatorQuantumObject, prod_dims::Int, 
 end
 
 function _check_QuantumObject(type::OperatorKetQuantumObject, prod_dims::Int, m::Int, n::Int)
-    (n != 1) ? throw(DomainError((m, n), "The dimension of the array is not compatible with Operator-Ket type")) : nothing
+    (n != 1) ? throw(DomainError((m, n), "The dimension of the array is not compatible with OperatorKet type")) : nothing
     prod_dims != sqrt(m) ? throw(DimensionMismatch("The dims parameter does not fit the dimension of the Array.")) : nothing
 end
 
 function _check_QuantumObject(type::OperatorBraQuantumObject, prod_dims::Int, m::Int, n::Int)
-    (m != 1) ? throw(DomainError((m, n), "The dimension of the array is not compatible with Operator-Bra type")) : nothing
+    (m != 1) ? throw(DomainError((m, n), "The dimension of the array is not compatible with OperatorBra type")) : nothing
     prod_dims != sqrt(n) ? throw(DimensionMismatch("The dims parameter does not fit the dimension of the Array.")) : nothing
 end
 
@@ -336,9 +336,9 @@ function Base.show(io::IO, ::MIME"text/plain", QO::QuantumObject{<:AbstractArray
     elseif op_type isa BraQuantumObject
         op_type = "Bra"
     elseif op_type isa OperatorKetQuantumObject
-        op_type = "Operator-Ket"
+        op_type = "OperatorKet"
     elseif op_type isa OperatorBraQuantumObject
-        op_type = "Operator-Bra"
+        op_type = "OperatorBra"
     else
         op_type = "SuperOperator"
     end

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -202,14 +202,14 @@
     datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
     ψ2_dims = ψ2.dims
     ψ2_size = size(ψ2)
-    @test opstring == "Quantum Object:   type=Operator-Ket   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+    @test opstring == "Quantum Object:   type=OperatorKet   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
 
     ψ2 = ψ2'
     opstring = sprint((t, s) -> show(t, "text/plain", s), ψ2)
     datastring = sprint((t, s) -> show(t, "text/plain", s), ψ2.data)
     ψ2_dims = ψ2.dims
     ψ2_size = size(ψ2)
-    @test opstring == "Quantum Object:   type=Operator-Bra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
+    @test opstring == "Quantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
 
     ψ = coherent(30, 3)
     α, δψ = get_coherence(ψ)


### PR DESCRIPTION
In PR #65, we defined the type constants `OperatorBra` and `OperatorKet`. But the output of `QuantumObject` is like:
```julia
julia> Qobj(rand(4), type=OperatorKet)
Quantum Object:   type=Operator-Ket   dims=[2]   size=(4,)
4-element Vector{Float64}:
 0.9398057156850064
 0.14617955497643975
 0.6029611022660892
 0.9449902837481058
```
There's an extra `-` in the type string, we should remove it to avoid ambiguity. Maybe this would also benefit some users when they do copy-and-paste.