### PR TITLE
Improve allocations for ProgressBar

### DIFF
--- a/src/eigsolve.jl
+++ b/src/eigsolve.jl
@@ -328,7 +328,6 @@ end
         alg::OrdinaryDiffEqAlgorithm=Tsit5(),
         H_t::Union{Nothing,Function}=nothing,
         params::NamedTuple=NamedTuple(),
-        progress::Bool=true,
         ρ0::Union{Nothing, AbstractMatrix} = nothing,
         k::Int=1,
         krylovdim::Int=min(10, size(H, 1)),
@@ -376,7 +375,7 @@ function eigsolve_al(H::QuantumObject{MT1,HOpType},
 
     L = liouvillian(H, c_ops)
     prob = mesolveProblem(L, QuantumObject(ρ0, dims=H.dims), [0,T]; alg=alg,
-            H_t=H_t, params=params, progress=false, kwargs...)
+            H_t=H_t, params=params, progress_bar=false, kwargs...)
     integrator = init(prob, alg)
 
     # prog = ProgressUnknown(desc="Applications:", showspeed = true, enabled=progress)

--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -13,6 +13,8 @@ function ProgressBar(max_counts::Int; enable::Bool=true, bar_width::Int=30)
 end
 
 function next!(p::ProgressBar, io::IO=stdout)
+    p.counter[] >= p.max_counts && return
+
     Threads.atomic_add!(p.counter, 1)
 
     !p.enable && return
@@ -40,7 +42,8 @@ function next!(p::ProgressBar, io::IO=stdout)
     bar = "[" * repeat("=", progress) * repeat(" ", bar_width - progress) * "]"
 
     print(io, "\rProgress: $bar $percentage_100% --- Elapsed Time: $elapsed_time_str (ETA: $eta_str)")
-    flush(io)
 
-    counter >= p.max_counts ? print(io, "\n") : nothing
+    counter == p.max_counts && print(io, "\n")
+
+    flush(io)
 end

--- a/src/progress_bar.jl
+++ b/src/progress_bar.jl
@@ -32,7 +32,7 @@ function next!(p::ProgressBar, io::IO=stdout)
     elapsed_time_str = string(elapsed_time ÷ 3600, "h ", lpad((elapsed_time % 3600) ÷ 60, 2, "0"), "m ", lpad(elapsed_time % 60, 2, "0"), "s")
 
     # Calculate the estimated time of arrival
-    eta = floor(Int, elapsed_time ÷ counter * (max_counts - counter))
+    eta = floor(Int, elapsed_time / counter * (max_counts - counter))
     # convert eta into a string in hours, minutes and seconds
     eta_str = string(eta ÷ 3600, "h ", lpad((eta % 3600) ÷ 60, 2, "0"), "m ", lpad(eta % 60, 2, "0"), "s")
 

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -13,7 +13,7 @@ function _save_func_mcsolve(integrator)
         normalize!(cache_mc)
         ψ = cache_mc
         _expect = op -> dot(ψ, op, ψ)
-        @. expvals[:, progr.counter+1] = _expect(e_ops)
+        @. expvals[:, progr.counter[]+1] = _expect(e_ops)
     end
     next!(progr)
     u_modified!(integrator, false)

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -83,7 +83,7 @@ function mesolveProblem(H::QuantumObject{MT1,HOpType},
 
     default_values = (abstol = 1e-7, reltol = 1e-5, saveat = [t_l[end]])
     kwargs2 = merge(default_values, kwargs)
-    if !isempty(e_ops)
+    if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_mesolve, save_positions=(false, false))
         kwargs2 = haskey(kwargs, :callback) ? merge(kwargs2, (callback=CallbackSet(kwargs2.callback, cb1),)) : merge(kwargs2, (callback=cb1,))
     end

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -13,7 +13,7 @@ function _save_func_mesolve(integrator)
         
         ρ = integrator.u
         _expect = op -> dot(op, ρ)
-        @. expvals[:, progr.counter+1] = _expect(e_ops)
+        @. expvals[:, progr.counter[]+1] = _expect(e_ops)
     end
     next!(progr)
     u_modified!(integrator, false)

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -11,7 +11,7 @@ function _save_func_sesolve(integrator)
 
         ψ = integrator.u
         _expect = op -> dot(ψ, op, ψ)
-        @. expvals[:, progr.counter+1] = _expect(e_ops)
+        @. expvals[:, progr.counter[]+1] = _expect(e_ops)
     end
     next!(progr)
     u_modified!(integrator, false)

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -76,7 +76,7 @@ function sesolveProblem(H::QuantumObject{MT1,OperatorQuantumObject},
 
     default_values = (abstol = 1e-7, reltol = 1e-5, saveat = [t_l[end]])
     kwargs2 = merge(default_values, kwargs)
-    if !isempty(e_ops)
+    if !isempty(e_ops) || progress_bar
         cb1 = PresetTimeCallback(t_l, _save_func_sesolve, save_positions=(false, false))
         kwargs2 = haskey(kwargs2, :callback) ? merge(kwargs2, (callback=CallbackSet(kwargs2.callback, cb1),)) : merge(kwargs2, (callback=cb1,))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,14 +24,14 @@ core_tests = [
     "wigner.jl",
 ]
 
-if (GROUP == "All") || (GROUP == "Core")
-    for test in core_tests
-        include(joinpath(testdir, test))
-    end
-end
-
 if (GROUP == "All") || (GROUP == "Code-Quality")
     Pkg.add(["Aqua", "JET"])
     include(joinpath(testdir, "aqua.jl"))
     include(joinpath(testdir, "jet.jl"))
+end
+
+if (GROUP == "All") || (GROUP == "Core")
+    for test in core_tests
+        include(joinpath(testdir, test))
+    end
 end


### PR DESCRIPTION
The `ProgressBar` functionality was allocating more memory than expected. With the current version, it does not allocate memory anymore. Moreover, the `ReentrantLock` is removed, since the `print` functions are already thread-safe. I changed the `counter` as an *Atomic* object, to update it in a thread-safe manner.