### PR TITLE
Element type conversion for `QuantumObject`

### DIFF
--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -196,10 +196,10 @@ function _check_QuantumObject(type::OperatorBraQuantumObject, prod_dims::Int, m:
     prod_dims != sqrt(n) ? throw(DimensionMismatch("The dims parameter does not fit the dimension of the Array.")) : nothing
 end
 
-function QuantumObject(A::QuantumObject{<:AbstractArray}; type::ObjType=A.type, dims=A.dims) where
-    {ObjType<:QuantumObjectType}
-
-    QuantumObject(A.data, type, dims)
+function QuantumObject(A::QuantumObject{<:AbstractArray{T,N}}; type::ObjType=A.type, dims=A.dims) where {T,N,ObjType<:QuantumObjectType}
+    N == 1 ? Size = (length(A), 1) : Size = size(A)
+    _check_QuantumObject(type, prod(dims), Size[1], Size[2])
+    return QuantumObject(copy(A.data), type, dims)
 end
 
 @doc raw"""
@@ -668,3 +668,13 @@ function _spexp(A::SparseMatrixCSC{T,M}; threshold=1e-14, nonzero_tol=1e-20) whe
     end
     P
 end
+
+# data type conversions
+Base.Vector(A::QuantumObject{<:AbstractVector}) = QuantumObject(Vector(A.data), A.type, A.dims)
+Base.Vector{T}(A::QuantumObject{<:AbstractVector}) where {T<:Number} = QuantumObject(Vector{T}(A.data), A.type, A.dims)
+Base.Matrix(A::QuantumObject{<:AbstractMatrix}) = QuantumObject(Matrix(A.data), A.type, A.dims)
+Base.Matrix{T}(A::QuantumObject{<:AbstractMatrix}) where {T<:Number} = QuantumObject(Matrix{T}(A.data), A.type, A.dims)
+SparseArrays.SparseVector(A::QuantumObject{<:AbstractVector}) = QuantumObject(SparseVector(A.data), A.type, A.dims)
+SparseArrays.SparseVector{T}(A::QuantumObject{<:SparseVector}) where {T<:Number} = QuantumObject(SparseVector{T}(A.data), A.type, A.dims)
+SparseArrays.SparseMatrixCSC(A::QuantumObject{<:AbstractMatrix}) = QuantumObject(SparseMatrixCSC(A.data), A.type, A.dims)
+SparseArrays.SparseMatrixCSC{T}(A::QuantumObject{<:SparseMatrixCSC}) where {T<:Number} = QuantumObject(SparseMatrixCSC{T}(A.data), A.type, A.dims)

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -238,4 +238,24 @@
     ρ2 = dense_to_sparse(ρ1)
     @test tidyup(ρ2, 0.1) != ρ2
     @test dense_to_sparse(tidyup(ρ1, 0.1)) == tidyup(ρ2, 0.1)
+
+    # data element type conversion
+    vd = Qobj(Int64[0, 0])
+    vs = Qobj(dense_to_sparse(vd))
+    Md = Qobj(Int64[0 0; 0 0])
+    Ms = Qobj(dense_to_sparse(Md))
+    @test typeof(Vector(vd).data) == Vector{Int64}
+    @test typeof(Vector(vs).data) == Vector{Int64}
+    @test typeof(Vector{ComplexF64}(vd).data) == Vector{ComplexF64}
+    @test typeof(Vector{ComplexF64}(vs).data) == Vector{ComplexF64}
+    @test typeof(SparseVector(vd).data) == SparseVector{Int64, Int64}
+    @test typeof(SparseVector(vs).data) == SparseVector{Int64, Int64}
+    @test typeof(SparseVector{ComplexF64}(vs).data) == SparseVector{ComplexF64, Int64}
+    @test typeof(Matrix(Md).data) == Matrix{Int64}
+    @test typeof(Matrix(Ms).data) == Matrix{Int64}
+    @test typeof(Matrix{ComplexF64}(Ms).data) == Matrix{ComplexF64}
+    @test typeof(Matrix{ComplexF64}(Md).data) == Matrix{ComplexF64}
+    @test typeof(SparseMatrixCSC(Md).data) == SparseMatrixCSC{Int64, Int64}
+    @test typeof(SparseMatrixCSC(Ms).data) == SparseMatrixCSC{Int64, Int64}
+    @test typeof(SparseMatrixCSC{ComplexF64}(Ms).data) == SparseMatrixCSC{ComplexF64, Int64}
 end


### PR DESCRIPTION
Support the following type conversion:
```julia
using QuantumToolbox
v = Qobj(Int64[1, 1])
m = Qobj(Int64[1, 1])

Vector{ComplexF64}(v)
Matrix{ComplexF64}(m)
```
and so does `SparseVector` and `SparseMatrixCSC`