### PR TITLE
Introduce `versioninfo()` and `about()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,4 +41,4 @@ julia = "1.7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "Test"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -37,7 +38,6 @@ Test = "<0.0.1, 1"
 julia = "1.7"
 
 [extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -135,3 +135,9 @@ _adjM_condition_ratio
 _pinv!
 dBdz!
 ```
+
+## [Miscellaneous](@id API: Miscellaneous)
+```@docs
+QuantumToolbox.versioninfo
+QuantumToolbox.about
+```

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -1,6 +1,6 @@
 module QuantumToolbox
 
-using Pkg
+import Pkg
 using Reexport
 using Distributed
 @reexport using LinearAlgebra

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -1,5 +1,6 @@
 module QuantumToolbox
 
+using Pkg
 using Reexport
 using Distributed
 @reexport using LinearAlgebra
@@ -20,6 +21,7 @@ using LinearAlgebra: BlasFloat, BlasComplex
 # to achieve better performances for more massive parallelizations
 BLAS.set_num_threads(1)
 
+include("versioninfo.jl")
 include("quantum_object.jl")
 include("quantum_operators.jl")
 include("general_functions.jl")

--- a/src/versioninfo.jl
+++ b/src/versioninfo.jl
@@ -54,7 +54,7 @@ function versioninfo(io::IO=stdout)
         """BLAS     : $(basename(BLAS_info.libname)) ($(BLAS_info.interface))"""
     )
     println(io,
-        """Threads  : $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)"""
+        """Threads  : $(Threads.nthreads()) on $(Sys.CPU_THREADS) virtual cores"""
     )
     print(io, "\n")
 end

--- a/src/versioninfo.jl
+++ b/src/versioninfo.jl
@@ -14,7 +14,8 @@ function versioninfo(io::IO=stdout)
         " QuantumToolbox.jl: Quantum Toolbox in Julia\n",
         "≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡\n",
         "Copyright © QuTiP team 2022 and later.\n",
-        "Current admin team: Alberto Mercurio, Yi-Te Huang\n",
+        "Current admin team:\n",
+        "    Alberto Mercurio, Luca Gravina, Yi-Te Huang\n"
     )
 
     # print package informations

--- a/src/versioninfo.jl
+++ b/src/versioninfo.jl
@@ -1,0 +1,76 @@
+"""
+    QuantumToolbox.versioninfo(io::IO=stdout)
+
+Command line output of information on QuantumToolbox, dependencies, and system information, same as [`QuantumToolbox.about`](@ref).
+"""
+function versioninfo(io::IO=stdout)
+    cpu = Sys.cpu_info()
+    BLAS_info = BLAS.get_config().loaded_libs[1]
+    Sys.iswindows() ? OS_name = "Windows" : Sys.isapple() ? OS_name = "macOS" : OS_name = Sys.KERNEL
+
+    # print introduction
+    println(io,
+        "\n",
+        " QuantumToolbox.jl: Quantum Toolbox in Julia\n",
+        "≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡\n",
+        "Copyright © QuTiP team 2022 and later.\n",
+        "Current admin team: Alberto Mercurio, Yi-Te Huang\n",
+    )
+
+    # print package informations
+    println(io,
+        "Package information:\n",
+        "====================================\n",
+        "QuantumToolbox  Ver. $(_get_pkg_version("QuantumToolbox"))\n",
+        "LinearSolve     Ver. $(_get_pkg_version("LinearSolve"))\n",
+        "OrdinaryDiffEq  Ver. $(_get_pkg_version("OrdinaryDiffEq"))\n"
+    )
+
+    # print System informations
+    println(io,
+        "System information:\n",
+        "====================================\n",
+        "Julia Version: $(VERSION)"
+    )
+    println(io, 
+        """OS       : $(OS_name) ($(Sys.MACHINE))"""
+    )
+    println(io, 
+        """CPU      : $(length(cpu)) × $(cpu[1].model)"""
+    )
+    println(io,
+        """Memory   : $(round(Sys.total_memory() / 2 ^ 30, digits=3)) GB"""
+    )
+    println(io, 
+        """WORD_SIZE: $(Sys.WORD_SIZE)"""
+    )
+    println(io, 
+        """LIBM     : $(Base.libm_name)"""
+    )
+    println(io, 
+        """LLVM     : libLLVM-$(Base.libllvm_version) ($(Sys.JIT), $(Sys.CPU_NAME))"""
+    )
+    println(io,
+        """BLAS     : $(basename(BLAS_info.libname)) ($(BLAS_info.interface))"""
+    )
+    println(io,
+        """Threads  : $(Threads.nthreads(:default)) default, $(Threads.nthreads(:interactive)) interactive, $(Threads.ngcthreads()) GC (on $(Sys.CPU_THREADS) virtual cores)"""
+    )
+    print(io, "\n")
+end
+
+"""
+    QuantumToolbox.about(io::IO=stdout)
+
+Command line output of information on QuantumToolbox, dependencies, and system information, same as [`QuantumToolbox.versioninfo`](@ref).
+"""
+about(io::IO=stdout) = versioninfo(io)
+
+function _get_pkg_version(pkg_name::String)
+    D = Pkg.dependencies()
+    for uuid in keys(D)
+        if D[uuid].name == pkg_name
+            return D[uuid].version
+        end
+    end
+end

--- a/src/versioninfo.jl
+++ b/src/versioninfo.jl
@@ -54,7 +54,7 @@ function versioninfo(io::IO=stdout)
         """BLAS     : $(basename(BLAS_info.libname)) ($(BLAS_info.interface))"""
     )
     println(io,
-        """Threads  : $(Threads.nthreads()) on $(Sys.CPU_THREADS) virtual cores"""
+        """Threads  : $(Threads.nthreads()) (on $(Sys.CPU_THREADS) virtual cores)"""
     )
     print(io, "\n")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,8 @@ if (GROUP == "All") || (GROUP == "Code-Quality")
 end
 
 if (GROUP == "All") || (GROUP == "Core")
+    QuantumToolbox.about()
+
     for test in core_tests
         include(joinpath(testdir, test))
     end


### PR DESCRIPTION
close #64
Add two (same) methods which will output the information of `QuantumToolbox`, dependencies, and system information:

- `QuantumToolbox.versioninfo()`
- `QuantumToolbox.about()`: similar to `QuTiP`

The current output is something like:
```
 QuantumToolbox.jl: Quantum Toolbox in Julia
≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
Copyright © QuTiP team 2022 and later.
Current admin team: Alberto Mercurio, Yi-Te Huang

Package information:
====================================
QuantumToolbox  Ver. 0.7.2
LinearSolve     Ver. 2.28.0
OrdinaryDiffEq  Ver. 6.74.1

System information:
====================================
Julia Version: 1.10.2
OS       : Windows (x86_64-w64-mingw32)
CPU      : 6 × Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz
Memory   : 15.918 GB
WORD_SIZE: 64
LIBM     : libopenlibm
LLVM     : libLLVM-15.0.7 (ORCJIT, skylake)
BLAS     : libopenblas64_.dll (ilp64)
Threads  : 1 (on 6 virtual cores)
```

@albertomercurio 
What do you think ? 
Do you want to add some intro., developer names, package information, or modify anything ?
