### PR TITLE
Immutable `QuantumObject`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # for core tests
+        # for core tests (latest and oldest supported versions)
         version:
-          - '1.8'
-          - '1.9'
+          - '1.7'
           - '1.10'
         os:
           - ubuntu-latest
@@ -42,8 +41,18 @@ jobs:
         group:
           - Core
 
-        # for code quality tests
         include:
+          # for core tests (intermediate versions)
+          - version: '1.8'
+            os: 'ubuntu-latest'
+            arch: 'x64'
+            group: 'Core'
+          - version: '1.9'
+            os: 'ubuntu-latest'
+            arch: 'x64'
+            group: 'Core'
+
+          # for code quality tests
           - version: '1'
             os: 'ubuntu-latest'
             arch: 'x64'

--- a/src/quantum_object.jl
+++ b/src/quantum_object.jl
@@ -96,7 +96,7 @@ A constant representing the type of [`OperatorKetQuantumObject`](@ref)
 const OperatorKet = OperatorKetQuantumObject()
 
 @doc raw"""
-    mutable struct QuantumObject{MT<:AbstractArray,ObjType<:QuantumObjectType}
+    struct QuantumObject{MT<:AbstractArray,ObjType<:QuantumObjectType}
         data::MT
         type::ObjType
         dims::Vector{Int}
@@ -120,7 +120,7 @@ julia> a isa QuantumObject
 true
 ```
 """
-mutable struct QuantumObject{MT<:AbstractArray,ObjType<:QuantumObjectType} <: AbstractQuantumObject
+struct QuantumObject{MT<:AbstractArray,ObjType<:QuantumObjectType} <: AbstractQuantumObject
     data::MT
     type::ObjType
     dims::Vector{Int}

--- a/src/spin_lattice.jl
+++ b/src/spin_lattice.jl
@@ -7,7 +7,7 @@ sm = (sx - 1im*sy)/2
 sp = (sx + 1im*sy)/2
 
 #Lattice structure
-Base.@kwdef mutable struct Lattice{TN<:Integer, TLI<:LinearIndices, TCI<:CartesianIndices}
+Base.@kwdef struct Lattice{TN<:Integer, TLI<:LinearIndices, TCI<:CartesianIndices}
     Nx::TN
     Ny::TN
     N::TN = Nx*Ny
@@ -18,9 +18,7 @@ end
 #Definition of many-body operators
 function mb(s::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, i::Integer, N::Integer) where {T1}
     T = s.dims[1]
-    op = kron(kron(eye(T^(i-1)), s), eye(T^(N-i)))
-    op.dims=ones(Int,N)*2
-    op
+    QuantumObject(kron(eye(T^(i-1)), s, eye(T^(N-i))); dims=fill(2, N))
 end
 mb(s::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, i::Integer, latt::Lattice) where {T1} = mb(s, i, latt.N)
 mb(s::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, row::Integer, col::Integer, latt::Lattice) where {T1} = mb(s, latt.idx[row,col], latt.N)

--- a/src/time_evolution/time_evolution.jl
+++ b/src/time_evolution/time_evolution.jl
@@ -39,7 +39,7 @@ ContinuousLindbladJumpCallback(;interp_points::Int=10) = ContinuousLindbladJumpC
 
 ## Sum of operators
 
-mutable struct OperatorSum{CT<:Vector{<:Number},OT<:Vector{<:QuantumObject}} <: AbstractQuantumObject
+struct OperatorSum{CT<:Vector{<:Number},OT<:Vector{<:QuantumObject}} <: AbstractQuantumObject
     coefficients::CT
     operators::OT
     function OperatorSum(coefficients::CT, operators::OT) where {CT<:Vector{<:Number},OT<:Vector{<:QuantumObject}}
@@ -76,7 +76,7 @@ end
     y
 end
 
-mutable struct TimeDependentOperatorSum{CFT,OST<:OperatorSum}
+struct TimeDependentOperatorSum{CFT,OST<:OperatorSum}
     coefficient_functions::CFT
     operator_sum::OST
 end


### PR DESCRIPTION
close #90

The summary of this PR:

- [x] make all `struct` immutable, including:
  - `QuantumObject`
  - `OperatorSum`
  - `TimeDependentOperatorSum`
  - `Lattice`
- [x] minor change for `spin_lattice.jl` to fit immutable `struct Lattice` (@lgravina1997 could you check whether this is correct)
- [x] Update runtests CI. Now the `Core` runtests will be running under the following Julia versions with different platforms (OS) as follows:
  - `Julia v1.7`: Windows, MacOS, Linux-Ubuntu
  - `Julia v1.8`: Linux-Ubuntu
  - `Julia v1.9`: Linux-Ubuntu
  - `Julia v1.10`: Windows, MacOS, Linux-Ubuntu