### PR TITLE
Fix local `JET` runtest

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ core_tests = [
     "wigner.jl",
 ]
 
-if (GROUP == "All") || (GROUP == "Code-Quality")
+if ((GROUP == "All") || (GROUP == "Code-Quality")) && (VERSION >= v"1.9")
     Pkg.add(["Aqua", "JET"])
     include(joinpath(testdir, "aqua.jl"))
     include(joinpath(testdir, "jet.jl"))


### PR DESCRIPTION
For local development, only run code quality tests under `VERSION >= v"1.9"`
Because `JET.test_package` does not support for `Julia v1.7`, and some errors will occur under `Julia v1.8`.