### PR TITLE
Add benchmark tracking

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,0 +1,60 @@
+name: Benchmark Tracking
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+    contents: write
+    deployments: write
+
+concurrency:
+    # Skip intermediate builds: always.
+    # Cancel intermediate builds: only if it is a pull request build.
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: x64
+      - uses: actions/cache@v4
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Run benchmark
+        run: |
+          cd benchmarks
+          julia --project --threads=2 --color=yes -e '
+            using Pkg;
+            Pkg.develop(PackageSpec(path=joinpath(pwd(), "..")));
+            Pkg.instantiate();
+            include("runbenchmarks.jl")'
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Julia benchmark result
+          tool: "julia"
+          output-file-path: benchmarks/benchmarks_output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name != 'pull_request' }}
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: "200%"
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: "@ktrz,@findmyway"

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -2,12 +2,22 @@ name: Benchmark Tracking
 on:
   push:
     branches:
-      - main
+      - 'main'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
-      - main
+      - 'main'
+    paths-ignore:
+      - 'docs/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
+    actions: write
     contents: write
     deployments: write
 
@@ -20,22 +30,14 @@ concurrency:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
           arch: x64
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - name: Run benchmark
         run: |
           cd benchmarks

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -45,16 +45,16 @@ jobs:
             Pkg.instantiate();
             include("runbenchmarks.jl")'
 
-      - name: Store benchmark result
+      - name: Parse & Upload Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Julia benchmark result
+          name: Benchmark results
           tool: "julia"
           output-file-path: benchmarks/benchmarks_output.json
+          summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name != 'pull_request' }}
-          # Show alert with commit comment on detecting possible performance regression
+          comment-always: true
           alert-threshold: "200%"
-          comment-on-alert: true
           fail-on-alert: true
-          alert-comment-cc-users: "@ktrz,@findmyway"
+          benchmark-data-dir-path: benchmarks
+          auto-push: ${{ github.event_name != 'pull_request' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .DS_Store
+
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
 Manifest.toml
 docs/build/
+
 .vscode
+*.json

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,1 +1,0 @@
-/benchmarks_output.json

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+/benchmarks_output.json

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+QuantumToolbox = "6c2fb7c5-b903-41d2-bc5e-5a7c320b9fab"

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -23,7 +23,8 @@ suite["steadystate"]["driven-dissipative harmonic oscillator"] = @benchmarkable 
 ## end ##
 
 
-tune!(suite)
+BenchmarkTools.tune!(suite)
 results = run(suite, verbose = true)
+display(median(results))
 
-BenchmarkTools.save("benchmarks_output.json", mean(results))
+BenchmarkTools.save(joinpath(@__DIR__, "benchmarks_output.json"), median(results))

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -1,0 +1,29 @@
+using BenchmarkTools
+using QuantumToolbox
+
+fib(n) = n <= 1 ?  1 : fib(n - 2) + fib(n - 1)
+
+suite = BenchmarkGroup()
+
+suite["steadystate"] = BenchmarkGroup(["steadystate"])
+
+
+## steadystate ##
+
+N = 50
+Δ = 0.1
+F = 2
+γ = 1
+a = destroy(N)
+H = Δ * a' * a + F * (a + a')
+c_ops = [sqrt(γ) * a]
+
+suite["steadystate"]["driven-dissipative harmonic oscillator"] = @benchmarkable steadystate($H, $c_ops)
+
+## end ##
+
+
+tune!(suite)
+results = run(suite, verbose = true)
+
+BenchmarkTools.save("benchmarks_output.json", mean(results))

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -1,8 +1,6 @@
 using BenchmarkTools
 using QuantumToolbox
 
-fib(n) = n <= 1 ?  1 : fib(n - 2) + fib(n - 1)
-
 suite = BenchmarkGroup()
 
 suite["steadystate"] = BenchmarkGroup(["steadystate"])


### PR DESCRIPTION
This PR introduces the feature of tracking the benchmark results over the commits, and produces warnings on PRs if the benchmarks regress.

It uses [https://github.com/benchmark-action/github-action-benchmark/](https://github.com/benchmark-action/github-action-benchmark/) and I used their examples as template, together with the [Lux.jl](https://github.com/LuxDL/Lux.jl) use.

Currently, I have added only the **steadystate** case, just to make it very minimal. Other benchmarks could be introduced in the following PRs, after checking that this actions works fine.