### PR TITLE
Support `svdvals`, generalize `norm`, and introduce `tracedist` for `Qobj`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,6 +58,7 @@ expect
 wigner
 get_coherence
 n_th
+tracedist
 get_data
 mat2vec
 vec2mat

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -32,6 +32,7 @@ size
 eltype
 length
 LinearAlgebra.tr
+LinearAlgebra.svdvals
 LinearAlgebra.norm
 LinearAlgebra.kron
 tensor

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -1,6 +1,6 @@
 export get_data, get_coherence, expect, ptrace
 export mat2vec, vec2mat
-export entropy_vn, entanglement
+export entropy_vn, entanglement, tracedist
 export gaussian, n_th
 
 export row_major_reshape, tidyup, tidyup!, meshgrid, sparse_to_dense, dense_to_sparse
@@ -328,9 +328,18 @@ function n_th(ω::Real, T::Real)::Float64
     return 1 / (exp(ω / T) - 1)
 end
 
+@doc raw"""
+    tracedist(A::QuantumObject, B::QuantumObject)
 
+Calculates the [trace distance](https://en.wikipedia.org/wiki/Trace_distance) between two [`QuantumObject`](@ref) `A` and `B`:
+``T(A, B) = frac{1}{2} \lVert A - B \rVert_1``
 
-
+Note that `A` and `B` must be either [`Ket`](@ref) or [`Operator`](@ref).
+"""
+tracedist(A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, B::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject}) where {T1,T2} = 0.5 * norm(A - B, 1)
+tracedist(A::QuantumObject{<:AbstractArray{T1},KetQuantumObject}, B::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject}) where {T1,T2} = tracedist(ket2dm(A), B)
+tracedist(A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, B::QuantumObject{<:AbstractArray{T2},KetQuantumObject}) where {T1,T2} = tracedist(A, ket2dm(B))
+tracedist(A::QuantumObject{<:AbstractArray{T1},KetQuantumObject}, B::QuantumObject{<:AbstractArray{T2},KetQuantumObject}) where {T1,T2} = tracedist(ket2dm(A), ket2dm(B))
 
 function _ptrace_ket(QO::AbstractArray{T1}, dims::Vector{<:Integer}, sel::Vector{T2}) where
     {T1,T2<:Integer}

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -329,17 +329,14 @@ function n_th(ω::Real, T::Real)::Float64
 end
 
 @doc raw"""
-    tracedist(A::QuantumObject, B::QuantumObject)
+    tracedist(ρ::QuantumObject, σ::QuantumObject)
 
-Calculates the [trace distance](https://en.wikipedia.org/wiki/Trace_distance) between two [`QuantumObject`](@ref) `A` and `B`:
-``T(A, B) = frac{1}{2} \lVert A - B \rVert_1``
+Calculates the [trace distance](https://en.wikipedia.org/wiki/Trace_distance) between two [`QuantumObject`](@ref):
+``T(\rho, \sigma) = frac{1}{2} \lVert \rho - \sigma \rVert_1``
 
 Note that `A` and `B` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
-tracedist(A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, B::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject}) where {T1,T2} = 0.5 * norm(A - B, 1)
-tracedist(A::QuantumObject{<:AbstractArray{T1},KetQuantumObject}, B::QuantumObject{<:AbstractArray{T2},OperatorQuantumObject}) where {T1,T2} = tracedist(ket2dm(A), B)
-tracedist(A::QuantumObject{<:AbstractArray{T1},OperatorQuantumObject}, B::QuantumObject{<:AbstractArray{T2},KetQuantumObject}) where {T1,T2} = tracedist(A, ket2dm(B))
-tracedist(A::QuantumObject{<:AbstractArray{T1},KetQuantumObject}, B::QuantumObject{<:AbstractArray{T2},KetQuantumObject}) where {T1,T2} = tracedist(ket2dm(A), ket2dm(B))
+tracedist(ρ::QuantumObject{<:AbstractArray{T1},ObjType1}, σ::QuantumObject{<:AbstractArray{T2},ObjType2}) where {T1,T2,ObjType1<:Union{KetQuantumObject,OperatorQuantumObject},ObjType2<:Union{KetQuantumObject,OperatorQuantumObject}} = 0.5 * norm(ket2dm(ρ) - ket2dm(σ), 1)
 
 function _ptrace_ket(QO::AbstractArray{T1}, dims::Vector{<:Integer}, sel::Vector{T2}) where
     {T1,T2<:Integer}

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -336,7 +336,7 @@ Calculates the [trace distance](https://en.wikipedia.org/wiki/Trace_distance) be
 
 Note that `A` and `B` must be either [`Ket`](@ref) or [`Operator`](@ref).
 """
-tracedist(ρ::QuantumObject{<:AbstractArray{T1},ObjType1}, σ::QuantumObject{<:AbstractArray{T2},ObjType2}) where {T1,T2,ObjType1<:Union{KetQuantumObject,OperatorQuantumObject},ObjType2<:Union{KetQuantumObject,OperatorQuantumObject}} = 0.5 * norm(ket2dm(ρ) - ket2dm(σ), 1)
+tracedist(ρ::QuantumObject{<:AbstractArray{T1},ObjType1}, σ::QuantumObject{<:AbstractArray{T2},ObjType2}) where {T1,T2,ObjType1<:Union{KetQuantumObject,OperatorQuantumObject},ObjType2<:Union{KetQuantumObject,OperatorQuantumObject}} = norm(ket2dm(ρ) - ket2dm(σ), 1) / 2
 
 function _ptrace_ket(QO::AbstractArray{T1}, dims::Vector{<:Integer}, sel::Vector{T2}) where
     {T1,T2<:Integer}

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -47,7 +47,7 @@ function negativity(ρ::QuantumObject, subsys::Int; logarithmic::Bool=false)
     end
 
     ρ_pt = partial_transpose(ρ, mask)
-    tr_norm = sum(sqrt, eigvals(ρ_pt' * ρ_pt))
+    tr_norm = norm(ρ_pt, 1) # trace norm
 
     if logarithmic
         return log2(tr_norm)
@@ -89,7 +89,7 @@ function _partial_transpose(ρ::QuantumObject{<:AbstractArray, OperatorQuantumOb
         [pt_dims[n, 3 - mask2[n]] for n in 1:nsys]  # opposite value in mask2 (1 -> 2, and 2 -> 1)
     ]
     return QuantumObject(
-        reshape(PermutedDimsArray(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
+        Matrix(reshape(PermutedDimsArray(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ))),
         Operator,
         ρ.dims
     )

--- a/src/negativity.jl
+++ b/src/negativity.jl
@@ -89,7 +89,7 @@ function _partial_transpose(ρ::QuantumObject{<:AbstractArray, OperatorQuantumOb
         [pt_dims[n, 3 - mask2[n]] for n in 1:nsys]  # opposite value in mask2 (1 -> 2, and 2 -> 1)
     ]
     return QuantumObject(
-        Matrix(reshape(PermutedDimsArray(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ))),
+        reshape(permutedims(reshape(ρ.data, (ρ.dims..., ρ.dims...)), pt_idx), size(ρ)),
         Operator,
         ρ.dims
     )

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -211,9 +211,20 @@
     ψ2_size = size(ψ2)
     @test opstring == "Quantum Object:   type=OperatorBra   dims=$ψ2_dims   size=$ψ2_size\n$datastring"
 
+    # get coherence
     ψ = coherent(30, 3)
     α, δψ = get_coherence(ψ)
     @test isapprox(abs(α), 3, atol=1e-5) && abs2(δψ[1]) > 0.999
+
+    # svdvals, Schatten p-norm
+    vd = Qobj(  rand(ComplexF64, 10))
+    vs = Qobj(sprand(ComplexF64, 100, 0.1))
+    Md = Qobj(  rand(ComplexF64, 10, 10))
+    Ms = Qobj(sprand(ComplexF64, 10, 10, 0.1))
+    @test svdvals(vd)[1] ≈ √(vd' * vd)
+    @test svdvals(vs)[1] ≈ √(vs' * vs)
+    @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md)))
+    @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms)))
 
     # Broadcasting
     a = destroy(20)

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -226,6 +226,17 @@
     @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md)))
     @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms)))
 
+    # trace distance
+    ψz0 = basis(2, 0)
+    ψz1 = basis(2, 1)
+    ρz0 = dense_to_sparse(ket2dm(ψz0))
+    ρz1 = dense_to_sparse(ket2dm(ψz1))
+    ψx0 = sqrt(0.5) * (basis(2, 0) + basis(2, 1))
+    @test tracedist(ψz0, ψx0) ≈ sqrt(0.5)
+    @test tracedist(ρz0, ψz1) ≈ 1.
+    @test tracedist(ψz1, ρz0) ≈ 1.
+    @test tracedist(ρz0, ρz1) ≈ 1.
+
     # Broadcasting
     a = destroy(20)
     for op in ((+), (-), (*), (^))

--- a/test/quantum_objects.jl
+++ b/test/quantum_objects.jl
@@ -220,11 +220,11 @@
     vd = Qobj(  rand(ComplexF64, 10))
     vs = Qobj(sprand(ComplexF64, 100, 0.1))
     Md = Qobj(  rand(ComplexF64, 10, 10))
-    Ms = Qobj(sprand(ComplexF64, 10, 10, 0.1))
+    Ms = Qobj(sprand(ComplexF64, 10, 10, 0.5))
     @test svdvals(vd)[1] ≈ √(vd' * vd)
     @test svdvals(vs)[1] ≈ √(vs' * vs)
-    @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md)))
-    @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms)))
+    @test norm(Md, 1) ≈ sum(sqrt, abs.(eigenenergies(Md' * Md))) atol=1e-6
+    @test norm(Ms, 1) ≈ sum(sqrt, abs.(eigenenergies(Ms' * Ms))) atol=1e-6
 
     # trace distance
     ψz0 = basis(2, 0)


### PR DESCRIPTION
The original `LinearAlgebra.norm` calculates standard vector norm no matter the input array is vector or matrix. But usually we calculate [Schatten p-norm](https://en.wikipedia.org/wiki/Schatten_norm) for matrices (density operators), which need to first calculate the singular values before taking the standard vector norm.

Summary for this PR:

- Support `LinearAlgebra.svdvals` (singular values) for `Qobj`
- Generalize `LinearAlgebra.norm(A::QuantumObject, p::Real=2)`:
  - if `Qobj` is `Ket`, `Bra`, `OperatorKet`, or `OperatorBra`, calculate the standard vector p-norm
  - if `Qobj` is `Operator` or `SuperOperator`, calculate the [Schatten p-norm](https://en.wikipedia.org/wiki/Schatten_norm)
- Since the definition of `negativity` is related to the trace-norm (Schatten 1-norm), use the above method directly can slightly increase the efficiency.
- Introduce `tracedist` (also relates to the trace-norm) between two given `Qobj`