### PR TITLE
Settings change for benchmark CI

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -48,7 +48,9 @@ jobs:
           tool: "julia"
           output-file-path: benchmarks/benchmarks_output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: "200%"
+          alert-threshold: "130%"
+          fail-threshold: "170%"
+          comment-on-alert: true
           fail-on-alert: true
           benchmark-data-dir-path: benchmarks
           max-items-in-chart: 100


### PR DESCRIPTION
Here I change some settings for the benchmark CI. I reduced the alert threshold to 130% and the CI fail to 170%.

I have also added the comment on alert option, that comments the commit if there is a descrease of performances.