### PR TITLE
Clean the code of liouvillian_floquet

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -18,12 +18,13 @@ function steadystate(
     solver::SteadyStateSolver = SteadyStateDirectSolver(),
 ) where {T,OpType<:Union{OperatorQuantumObject,SuperOperatorQuantumObject}}
     L = liouvillian(H, c_ops)
+
     return steadystate(L, solver = solver)
 end
 
 function _steadystate(
     L::QuantumObject{<:AbstractArray{T},SuperOperatorQuantumObject},
-    solver::SteadyStateSolver,
+    solver::SteadyStateDirectSolver,
 ) where {T}
     L_tmp = copy(L.data)
     N = prod(L.dims)
@@ -43,7 +44,8 @@ end
     steadystate_floquet(H_0::QuantumObject,
         c_ops::Vector, H_p::QuantumObject,
         H_m::QuantumObject,
-        ω::Real; n_max::Int=4, lf_solver::LiouvillianSolver=LiouvillianDirectSolver(),
+        ω::Real; n_max::Int=4,
+        tol::Real=1e-15,
         ss_solver::SteadyStateSolver=SteadyStateDirectSolver())
 
 Calculates the steady state of a periodically driven system.
@@ -52,7 +54,6 @@ Considering a monochromatic drive at frequency ``\\omega``, we divide it into tw
 `H_p` and `H_m`, where `H_p` oscillates
 as ``e^{i \\omega t}`` and `H_m` oscillates as ``e^{-i \\omega t}``.
 `n_max` is the number of iterations used to obtain the effective Liouvillian,
-`lf_solver` is the solver used to solve the effective Liouvillian,
 and `ss_solver` is the solver used to solve the steady state.
 """
 function steadystate_floquet(
@@ -62,7 +63,7 @@ function steadystate_floquet(
     H_m::QuantumObject{<:AbstractArray{T3},OpType3},
     ω::Real;
     n_max::Int = 4,
-    lf_solver::LiouvillianSolver = LiouvillianDirectSolver(),
+    tol::Real = 1e-15,
     ss_solver::SteadyStateSolver = SteadyStateDirectSolver(),
 ) where {
     T1,
@@ -76,7 +77,7 @@ function steadystate_floquet(
     L_p = liouvillian(H_p)
     L_m = liouvillian(H_m)
 
-    return steadystate(liouvillian_floquet(L_0, L_p, L_m, ω, n_max = n_max, solver = lf_solver), solver = ss_solver)
+    return steadystate(liouvillian_floquet(L_0, L_p, L_m, ω, n_max = n_max, tol = tol), solver = ss_solver)
 end
 
 function steadystate_floquet(
@@ -85,7 +86,7 @@ function steadystate_floquet(
     H_m::QuantumObject{<:AbstractArray{T3},OpType3},
     ω::Real;
     n_max::Int = 4,
-    lf_solver::LiouvillianSolver = LiouvillianDirectSolver(),
+    tol::Real = 1e-15,
     ss_solver::SteadyStateSolver = SteadyStateDirectSolver(),
 ) where {
     T1,
@@ -99,5 +100,5 @@ function steadystate_floquet(
     L_p = liouvillian(H_p)
     L_m = liouvillian(H_m)
 
-    return steadystate(liouvillian_floquet(L_0, L_p, L_m, ω, n_max = n_max, solver = lf_solver), solver = ss_solver)
+    return steadystate(liouvillian_floquet(L_0, L_p, L_m, ω, n_max = n_max, tol = tol), solver = ss_solver)
 end


### PR DESCRIPTION
I clean the code related to the `liouvillian_floquet` function. Specifically, I deleted the solver definition (there is only one solver, and it is not so direct to find another way to solve it at the moment). So I decided to remove it and simplify the code.