### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmarks/correlations_and_spectrum.jl
+++ b/benchmarks/correlations_and_spectrum.jl
@@ -1,4 +1,4 @@
-function benchmark_correlations_and_spectrum()
+function benchmark_correlations_and_spectrum!(SUITE)
     N = 15
     ω = 1
     γ = 0.1
@@ -10,18 +10,10 @@ function benchmark_correlations_and_spectrum()
 
     ω_l = range(0, 3, length = 1000)
 
-    SUITE["Correlations and Spectrum"]["FFT Correlation"] = @benchmarkable spectrum(
-        $H,
-        $ω_l,
-        $(a'),
-        $a,
-        $c_ops,
-        solver = FFTCorrelation(),
-        progress_bar = false,
-    )
+    SUITE["Correlations and Spectrum"]["FFT Correlation"] =
+        @benchmarkable spectrum($H, $ω_l, $(a'), $a, $c_ops, solver = FFTCorrelation(), progress_bar = false)
 
-    SUITE["Correlations and Spectrum"]["Exponential Series"] =
-        @benchmarkable spectrum($H, $ω_l, $(a'), $a, $c_ops)
+    SUITE["Correlations and Spectrum"]["Exponential Series"] = @benchmarkable spectrum($H, $ω_l, $(a'), $a, $c_ops)
+
+    return nothing
 end
-
-benchmark_correlations_and_spectrum()

--- a/benchmarks/dynamical_fock_dimension.jl
+++ b/benchmarks/dynamical_fock_dimension.jl
@@ -4,21 +4,21 @@ function H_dfd2(dims, p)
     J = p.J
     a = tensor(destroy(dims[1]), qeye(dims[2]))
     b = tensor(qeye(dims[1]), destroy(dims[2]))
-    Δ * a' * a + F * (a + a') + Δ * b' * b + J * (a' * b + a * b')
+    return Δ * a' * a + F * (a + a') + Δ * b' * b + J * (a' * b + a * b')
 end
 function c_ops_dfd2(dims, p)
     κ = p.κ
     a = tensor(destroy(dims[1]), qeye(dims[2]))
     b = tensor(qeye(dims[1]), destroy(dims[2]))
-    [√κ * a, √κ * b]
+    return [√κ * a, √κ * b]
 end
 function e_ops_dfd2(dims, p)
     a = tensor(destroy(dims[1]), qeye(dims[2]))
     b = tensor(qeye(dims[1]), destroy(dims[2]))
-    [a' * a, b' * b]
+    return [a' * a, b' * b]
 end
 
-function benchmark_dfd()
+function benchmark_dfd!(SUITE)
     F, Δ, κ, J = 1, 0.25, 1, 0.05
     maxdims = [50, 50]
 
@@ -37,6 +37,6 @@ function benchmark_dfd()
         e_ops = e_ops_dfd2,
         progress_bar = false,
     )
-end
 
-benchmark_dfd()
+    return nothing
+end

--- a/benchmarks/eigenvalues.jl
+++ b/benchmarks/eigenvalues.jl
@@ -1,4 +1,4 @@
-function benchmark_eigenvalues()
+function benchmark_eigenvalues!(SUITE)
     N = 5
     a = tensor(destroy(N), qeye(N))
     a_d = a'
@@ -16,8 +16,7 @@ function benchmark_eigenvalues()
     L = liouvillian(H, c_ops)
 
     SUITE["Eigenvalues"]["eigenstates"]["dense"] = @benchmarkable eigenstates($L)
-    SUITE["Eigenvalues"]["eigenstates"]["sparse"] =
-        @benchmarkable eigenstates($L, sparse = true, sigma = 0.01, k = 5)
-end
+    SUITE["Eigenvalues"]["eigenstates"]["sparse"] = @benchmarkable eigenstates($L, sparse = true, sigma = 0.01, k = 5)
 
-benchmark_eigenvalues()
+    return nothing
+end

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -11,6 +11,12 @@ include("eigenvalues.jl")
 include("steadystate.jl")
 include("timeevolution.jl")
 
+benchmark_correlations_and_spectrum!(SUITE)
+benchmark_dfd!(SUITE)
+benchmark_eigenvalues!(SUITE)
+benchmark_steadystate!(SUITE)
+benchmark_timeevolution!(SUITE)
+
 BenchmarkTools.tune!(SUITE)
 results = BenchmarkTools.run(SUITE, verbose = true)
 display(median(results))

--- a/benchmarks/steadystate.jl
+++ b/benchmarks/steadystate.jl
@@ -1,4 +1,4 @@
-function benchmark_steadystate()
+function benchmark_steadystate!(SUITE)
     N = 50
     Δ = 0.1
     F = 2
@@ -10,6 +10,6 @@ function benchmark_steadystate()
     c_ops = [sqrt(γ * (nth + 1)) * a, sqrt(γ * nth) * a']
 
     SUITE["Steadystate"]["Direct"] = @benchmarkable steadystate($H, $c_ops)
-end
 
-benchmark_steadystate()
+    return nothing
+end

--- a/benchmarks/timeevolution.jl
+++ b/benchmarks/timeevolution.jl
@@ -1,4 +1,4 @@
-function benchmark_timeevolution()
+function benchmark_timeevolution!(SUITE)
     ωc = 1
     ωq = 1
     g = 0.1
@@ -37,39 +37,31 @@ function benchmark_timeevolution()
 
     tlist = range(0, 10 / γ, 100)
 
-    SUITE["Time Evolution"]["time-independent"]["mesolve"] = @benchmarkable mesolve(
+    SUITE["Time Evolution"]["time-independent"]["mesolve"] =
+        @benchmarkable mesolve($H, $ψ0, $tlist, $c_ops, e_ops = $e_ops, progress_bar = false)
+
+    ## mcsolve ##
+
+    SUITE["Time Evolution"]["time-independent"]["mcsolve"]["Serial"] = @benchmarkable mcsolve(
         $H,
         $ψ0,
         $tlist,
         $c_ops,
+        n_traj = 100,
         e_ops = $e_ops,
         progress_bar = false,
+        ensemble_method = EnsembleSerial(),
+    )
+    SUITE["Time Evolution"]["time-independent"]["mcsolve"]["Multithreaded"] = @benchmarkable mcsolve(
+        $H,
+        $ψ0,
+        $tlist,
+        $c_ops,
+        n_traj = 100,
+        e_ops = $e_ops,
+        progress_bar = false,
+        ensemble_method = EnsembleThreads(),
     )
 
-    ## mcsolve ##
-
-    SUITE["Time Evolution"]["time-independent"]["mcsolve"]["Serial"] =
-        @benchmarkable mcsolve(
-            $H,
-            $ψ0,
-            $tlist,
-            $c_ops,
-            n_traj = 100,
-            e_ops = $e_ops,
-            progress_bar = false,
-            ensemble_method = EnsembleSerial(),
-        )
-    SUITE["Time Evolution"]["time-independent"]["mcsolve"]["Multithreaded"] =
-        @benchmarkable mcsolve(
-            $H,
-            $ψ0,
-            $tlist,
-            $c_ops,
-            n_traj = 100,
-            e_ops = $e_ops,
-            progress_bar = false,
-            ensemble_method = EnsembleThreads(),
-        )
+    return nothing
 end
-
-benchmark_timeevolution()


### PR DESCRIPTION
This is a PR to improve the code format suggested in PR #116.

Since the benchmark functions modifies the variable `SUITE`.
These functions should:
- take `SUITE` as an input
- name as `benchmark_XXX!`
- `return nothing`