### PR TITLE
Make steadystate function almost compatible with GPU arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Alberto Mercurio"]
 version = "0.8.2"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
@@ -25,6 +26,7 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 QuantumToolboxCUDAExt = "CUDA"
 
 [compat]
+ArrayInterface = "6, 7"
 CUDA = "5"
 DiffEqCallbacks = "2, 3"
 FFTW = "1.5"

--- a/src/QuantumToolbox.jl
+++ b/src/QuantumToolbox.jl
@@ -30,6 +30,7 @@ import LinearMaps: LinearMap
 import Pkg
 import Random
 import SpecialFunctions: loggamma
+using ArrayInterface: allowed_getindex, allowed_setindex!
 
 # Setting the number of threads to 1 allows
 # to achieve better performances for more massive parallelizations

--- a/src/general_functions.jl
+++ b/src/general_functions.jl
@@ -442,3 +442,6 @@ Convert a quantum object from matrix ([`OperatorQuantumObject`](@ref)-type) to v
 """
 mat2vec(A::QuantumObject{<:AbstractArray{T},OperatorQuantumObject}) where {T} =
     QuantumObject(mat2vec(A.data), OperatorKet, A.dims)
+
+_get_dense_similar(A::AbstractArray, args...) = similar(A, args...)
+_get_dense_similar(A::AbstractSparseMatrix, args...) = similar(nonzeros(A), args...)


### PR DESCRIPTION
I make the `steadystate` function GPU-compatible.

I now create the matrix and the vector for the linear system, depending on the type of the input liouvillian.

Currently, the only feature not yet supported by GPUs is `A \ b`, but it might be implemented in the future.

This could be solved using iterative algorithms of **LinearSolve.jl**, which will be inplemented in the next PRs related to #81.